### PR TITLE
feat(link_validator): support nested subgroup

### DIFF
--- a/gdcdatamodel/validators/graph_validators.py
+++ b/gdcdatamodel/validators/graph_validators.py
@@ -1,6 +1,5 @@
 from dictionaryutils import dictionary as gdcdictionary
-import psqlgraph
-import sqlalchemy
+from collections import deque
 
 
 class GDCGraphValidator(object):
@@ -9,6 +8,7 @@ class GDCGraphValidator(object):
     database.
 
     '''
+
     def __init__(self):
         self.schemas = gdcdictionary
         self.required_validators = {
@@ -29,87 +29,286 @@ class GDCGraphValidator(object):
                     self.optional_validators[validator_name].validate()
 
 
+class SubgroupParsingNode(object):
+    def __init__(self, parent, schema, code=None):
+        self.parent = parent
+        self.schema = schema
+        self.code = code
+        self.name = schema.get('name') if 'name' in schema else None
+        self.required = schema.get('required', False)
+        self.exclusive = schema.get('exclusive', False)
+        self.required_links = []
+        self.existing_mask = None
+        self.existing_links = []
+        self.exclusive_mask = 0
+        self.exclusive_links = []
+        self.all_ancestors_required = parent.all_ancestors_required and parent.required \
+            if parent is not None else self.required
+        self.all_ancestors_inclusive = parent.all_ancestors_inclusive and not parent.exclusive \
+            if parent is not None else not self.exclusive
+
+    def update_existing_mask(self, current, parent, child, update_mask_should_fix):
+        parent.existing_mask = current.existing_mask if parent.existing_mask is None \
+            else parent.existing_mask | current.existing_mask
+        parent.existing_links.append(child.name)
+        current.existing_mask = None
+        current.existing_links = []
+        if not parent.required:
+            update_mask_should_fix = False
+        return update_mask_should_fix
+
+    def update_exclusive_mask(self, link):
+        stack = []
+        current = link
+        while current.parent and not current.all_ancestors_inclusive:
+            parent = current.parent
+            if parent.exclusive:
+                parent.exclusive_mask |= link.code
+                parent.exclusive_links.append(link.name)
+            stack.append(current)
+            current = parent
+
+        while len(stack) > 0:
+            parent = current
+            current = stack.pop()
+            if parent.exclusive:
+                current.exclusive_mask = parent.exclusive_mask ^ current.code
+            else:
+                current.exclusive_mask = parent.exclusive_mask
+            current.exclusive_links = parent.exclusive_links
+
+    def update_parent(self, child):
+        update_mask_should_fix = child.required
+        self.code = child.code if self.code is None else self.code | child.code
+        if update_mask_should_fix:
+            self.existing_mask = child.code if self.existing_mask is None else self.existing_mask | child.code
+            self.existing_links.append(child.name)
+
+        current_sg = self
+        if not current_sg.required:
+            update_mask_should_fix = False
+        if current_sg.required:
+            current_sg.required_links.append(child.name)
+
+        while current_sg is not None:
+            parent = current_sg.parent
+            if parent is not None:
+                if update_mask_should_fix:
+                    update_mask_should_fix = self.update_existing_mask(current_sg, parent, child, update_mask_should_fix)
+                parent.code = current_sg.code if parent.code is None else parent.code | current_sg.code
+                if parent.required:
+                    parent.required_links.append(child.name)
+            current_sg = parent
+        self.update_exclusive_mask(child)
+
+    def add_child_link(self, child):
+        self.update_parent(child)
+
+
+class LinkWithExclusiveMask(object):
+    def __init__(self, item):
+        self.name = item.name
+        self.exclusive_mask = item.exclusive_mask
+        self.exclusive_links = item.exclusive_links
+        self.multiplicity = item.schema.get('multiplicity')
+        self.back_ref = item.schema.get('backref')
+
+
+class ExistingMasks(object):
+    def __init__(self, code, existing_mask, existing_links):
+        self.code = code
+        self.existing_mask = existing_mask
+        self.existing_links = existing_links
+
+
+class RequiredMask(object):
+    def __init__(self):
+        self.list_required_links = []
+        self.group_required = []
+        self.required_mask = 0
+
+
+class GDCNamedLinksValidator(object):
+    '''
+    First of all, the existence of links in each node is encoded as a bit array. Link has value encoded as 1 and 0 if
+        does not have value.
+    Each instance of this class have three encoded validators:
+    - required:
+        Use at-least mask.
+        Encodes logic of top-down requires in which parent subgroup require the existence of some children.
+        This validation will be checked by operation & between required_mask and bit_array_value
+        to ensure at least one bit = 1
+    - existing:
+        1. encodes logic of bottom-up existence group. If some children of a subgroup have required=True
+        while the subgroup itself has required=False. It means that if one of aforementioned children exists, the
+        remaining children having required=True in that subgroup must also exist.
+        2. it also encodes the logic of the really required links.
+
+        Use exact mask for the existing group
+    - exclusive:
+        simply a mask with bits representing to considering links equal 0 while bits representing exclusive links
+        of those links are 1
+
+    '''
+    def __init__(self, node_label):
+        self.required_validator, self.existing_list, self.exclusive_list = self.create_subgroup_validators(node_label)
+
+    @staticmethod
+    def create_subgroup_validators(node_label):
+        link_items = []
+        leaves = []
+        for link in gdcdictionary.schema[node_label]['links']:
+            if 'name' in link:
+                l_item = SubgroupParsingNode(None, link, 1 << len(leaves))
+                leaves.append(l_item)
+            else:
+                l_item = SubgroupParsingNode(None, link)
+            link_items.append(l_item)
+
+        return GDCNamedLinksValidator.build_tree_of_link_items(link_items, leaves)
+
+    @staticmethod
+    def build_tree_of_link_items(link_items, leaves):
+        final_required = []
+        current_pos = 0
+        while current_pos < len(link_items):
+            l_item = link_items[current_pos]
+            children_required_count = 0
+            if 'subgroup' in l_item.schema:
+                for link in l_item.schema['subgroup']:
+                    if 'subgroup' in link:
+                        new_l_item = SubgroupParsingNode(l_item, link)
+                    else:
+                        new_l_item = SubgroupParsingNode(l_item, link, 1 << len(leaves))
+                        l_item.add_child_link(new_l_item)
+                        leaves.append(new_l_item)
+
+                    link_items.append(new_l_item)
+
+                    if l_item.required and new_l_item.required:
+                        children_required_count += 1
+            if l_item.all_ancestors_required and l_item.required and children_required_count == 0:
+                final_required.append(l_item)
+            current_pos += 1
+
+        required_validator, base_mask = GDCNamedLinksValidator.create_required_mask(final_required)
+        existing_list = GDCNamedLinksValidator.create_existing_list(link_items, base_mask)
+        exclusive_list = GDCNamedLinksValidator.create_exclusive_list(leaves)
+
+        return required_validator, existing_list, exclusive_list
+
+    @staticmethod
+    def create_exclusive_list(leaves):
+        if len(leaves) == 0:
+            return []
+
+        current = leaves[len(leaves) - 1]
+        leaves_checks = deque([LinkWithExclusiveMask(current)])
+        i = len(leaves) - 2
+        while i >= 0:
+            leaf = leaves[i]
+            if leaf.parent == current.parent:
+                leaf.exclusive_links = current.exclusive_links
+            else:
+                current = leaf
+            leaves_checks.appendleft(LinkWithExclusiveMask(leaf))
+            i -= 1
+        return list(leaves_checks)
+
+    @staticmethod
+    def create_existing_list(link_items, base_mask):
+        existing_masks = []
+        for item in link_items:
+            if item.existing_mask is not None:
+                existing_masks.append(ExistingMasks(item.code, item.existing_mask | base_mask,
+                                                    item.existing_links))
+        return existing_masks
+
+    @staticmethod
+    def create_required_mask(final_required):
+        res = RequiredMask()
+        base_mask = 0
+        for item in final_required:
+            res.required_mask |= item.code
+            if item.name is not None:
+                res.list_required_links.append(item.name)
+                base_mask |= item.code  # if the require is True from the root to the leaf, this leaf is really required
+            else:
+                res.group_required.extend(item.required_links)
+        return res, base_mask
+
+    def validate(self, entity):
+        coded_format = 0
+        current_pos = 0
+        # iterate all the links, turn on corresponding bit and doing exclusive check
+        for leaf in self.exclusive_list:
+            targets = entity.node[leaf.name]
+            self.validate_multiplicity(entity, leaf, targets)
+            if len(targets) > 0:
+                if coded_format & leaf.exclusive_mask != 0:
+                    entity.record_error("Links to {} are exclusive.  More than one was provided."
+                                        .format(leaf.exclusive_links), keys=leaf.exclusive_links)
+                coded_format |= 1 << current_pos
+            current_pos += 1
+
+        # doing required check with at-least mask
+        if coded_format & self.required_validator.required_mask == 0:
+            entity.record_error("Entity is missing one of required link(s) to {} or groups of {}"
+                                .format(self.required_validator.list_required_links,
+                                        self.required_validator.group_required),
+                                keys=self.required_validator.list_required_links)
+
+        # doing existing checks with exact masks
+        for existing in self.existing_list:
+            if coded_format & existing.code != 0 and coded_format & existing.existing_mask != existing.existing_mask:
+                entity.record_error("Missing one of required link(s) of groups of {}"
+                                    .format(existing.existing_links),
+                                    keys=existing.existing_links)
+
+    @staticmethod
+    def validate_multiplicity(entity, leaf, targets):
+        multi = leaf.multiplicity
+        if multi in ['many_to_one', 'one_to_one']:
+            if len(targets) > 1:
+                entity.record_error("'{}' link has to be {}".format(leaf.name, multi), keys=[leaf.name])
+
+        if multi in ['one_to_many', 'one_to_one']:
+            for target in targets:
+                if len(target[leaf.backref]) > 1:
+                    entity.record_error(
+                        "'{}' link has to be {}, target node {} already has {}"
+                        .format(leaf.name, multi, target.label, leaf.backref),
+                        keys=[leaf.name])
+
+
 class GDCLinksValidator(object):
+    '''
+    This class have a hash table of validators by name of node. This table caches all necessary link validators
+    of a node which belong to four types:
+        - required
+        - existing
+        - exclusive
+        - multiplicity.
+    The first three types are encoded as bit mask. We only need to build the validators once when the node is
+    submitted first time. Later, we just do iterating and perform bit masking operation.
+    '''
+    def __init__(self):
+        self.validators = {}
 
     def validate(self, entities, graph=None):
+        node_label = entities[0].node.label
+        if node_label not in self.validators:
+            self.validators[node_label] = GDCNamedLinksValidator(node_label)
         for entity in entities:
-            for link in gdcdictionary.schema[entity.node.label]['links']:
-                if 'name' in link:
-                    self.validate_edge(link, entity)
-                elif 'subgroup' in link:
-                    self.validate_edge_group(link, entity)
+            self.validators[node_label].validate(entity)
 
-    def validate_edge_group(self, schema, entity):
-        submitted_links = []
-        schema_links = []
-        num_of_edges = 0
-
-        for group in schema['subgroup']:
-            if 'subgroup' in schema['subgroup']:
-                # nested subgroup
-                result = self.validate_edge_group(group, entity)
-            if 'name' in group:
-                result = self.validate_edge(group, entity)
-
-            if result['length'] > 0:
-                submitted_links.append(result)
-                num_of_edges += result['length']
-            schema_links.append(result['name'])
-
-        if schema.get('required') is True and len(submitted_links) == 0:
-            names = ", ".join(
-                schema_links[:-2] + [" or ".join(schema_links[-2:])])
-            entity.record_error(
-                "Entity is missing a required link to {}"
-                .format(names), keys=schema_links)
-
-        if schema.get("exclusive") is True and len(submitted_links) > 1:
-            names = ", ".join(
-                schema_links[:-2] + [" and ".join(schema_links[-2:])])
-            entity.record_error(
-                "Links to {} are exclusive.  More than one was provided."
-                .format(schema_links), keys=schema_links)
-
-        result = {'length': num_of_edges, 'name': ", ".join(schema_links)}
-
-    def validate_edge(self, link_sub_schema, entity):
-        association = link_sub_schema['name']
-        node = entity.node
-        targets = node[association]
-        result = {'length': len(targets), 'name': association}
-
-        if len(targets) > 0:
-            multi = link_sub_schema['multiplicity']
-
-            if multi in ['many_to_one', 'one_to_one']:
-                if len(targets) > 1:
-                    entity.record_error(
-                        "'{}' link has to be {}"
-                        .format(association, multi),
-                        keys=[association])
-
-            if multi in ['one_to_many', 'one_to_one']:
-                for target in targets:
-                    if len(target[link_sub_schema['backref']]) > 1:
-                        entity.record_error(
-                            "'{}' link has to be {}, target node {} already has {}"
-                            .format(association, multi,
-                                    target.label, link_sub_schema['backref']),
-                            keys=[association])
-
-            if multi == 'many_to_many':
-                pass
-        else:
-            if link_sub_schema.get('required') is True:
-                entity.record_error(
-                    "Entity is missing required link to {}"
-                    .format(association),
-                    keys=[association])
-        return result
+    def get_validator(self, node_label):
+        if node_label not in self.validators:
+            self.validators[node_label] = GDCNamedLinksValidator(node_label)
+        return self.validators
 
 
 class GDCUniqueKeysValidator(object):
-
     def validate(self, entities, graph=None):
         for entity in entities:
             schema = gdcdictionary.schema[entity.node.label]
@@ -125,7 +324,7 @@ class GDCUniqueKeysValidator(object):
                     else:
                         props[key] = node[key]
                 if graph.nodes(type(node)).props(props).count() > 1:
-                        entity.record_error(
-                            '{} with {} already exists in the GDC'
+                    entity.record_error(
+                        '{} with {} already exists in the GDC'
                             .format(node.label, props), keys=props.keys()
-                        )
+                    )

--- a/gdcdatamodel/validators/graph_validators.py
+++ b/gdcdatamodel/validators/graph_validators.py
@@ -58,7 +58,7 @@ class GDCNamedLinksValidator(object):
         submit_value = 0
         current_pos = 0
         # iterate all the links, turn on corresponding bit and doing exclusive check
-        for leaf in self.exclusive_list:
+        for leaf in self.exclusive_list:  # Complexity of this for loop is O(n)
             targets = entity.node[leaf.name]
             self.validate_multiplicity(entity, leaf, targets)
             if len(targets) > 0:
@@ -69,14 +69,15 @@ class GDCNamedLinksValidator(object):
             current_pos += 1
 
         # doing required check with at-least mask
-        if submit_value & self.required_validator.required_mask == 0:
+        # Complexity of this is O(1)
+        if self.required_validator.required_mask != 0 and submit_value & self.required_validator.required_mask == 0:
             entity.record_error("Entity is missing one of required link(s) to {} or groups of {}"
                                 .format(self.required_validator.list_required_links,
                                         self.required_validator.group_required),
                                 keys=self.required_validator.list_required_links)
 
         # doing existing checks with exact masks
-        for existing in self.existing_list:
+        for existing in self.existing_list:  # Complexity of this check is O(log n)
             if submit_value & existing.code != 0 and submit_value & existing.existing_mask != existing.existing_mask:
                 entity.record_error("Missing one of required link(s) of groups of {}"
                                     .format(existing.existing_links),
@@ -113,6 +114,8 @@ class GDCLinksValidator(object):
         self.validators = {}
 
     def validate(self, entities, graph=None):
+        if len(entities) <= 0:
+            return
         node_label = entities[0].node.label
         if node_label not in self.validators:
             self.validators[node_label] = GDCNamedLinksValidator(node_label)

--- a/gdcdatamodel/validators/graph_validators.py
+++ b/gdcdatamodel/validators/graph_validators.py
@@ -1,5 +1,5 @@
 from dictionaryutils import dictionary as gdcdictionary
-from collections import deque
+from link_validator_parser import create_subgroup_validators
 
 
 class GDCGraphValidator(object):
@@ -29,105 +29,6 @@ class GDCGraphValidator(object):
                     self.optional_validators[validator_name].validate()
 
 
-class SubgroupParsingNode(object):
-    def __init__(self, parent, schema, code=None):
-        self.parent = parent
-        self.schema = schema
-        self.code = code
-        self.name = schema.get('name') if 'name' in schema else None
-        self.required = schema.get('required', False)
-        self.exclusive = schema.get('exclusive', False)
-        self.required_links = []
-        self.existing_mask = None
-        self.existing_links = []
-        self.exclusive_mask = 0
-        self.exclusive_links = []
-        self.all_ancestors_required = parent.all_ancestors_required and parent.required \
-            if parent is not None else self.required
-        self.all_ancestors_inclusive = parent.all_ancestors_inclusive and not parent.exclusive \
-            if parent is not None else not self.exclusive
-
-    def update_existing_mask(self, current, parent, child, update_mask_should_fix):
-        parent.existing_mask = current.existing_mask if parent.existing_mask is None \
-            else parent.existing_mask | current.existing_mask
-        parent.existing_links.append(child.name)
-        current.existing_mask = None
-        current.existing_links = []
-        if not parent.required:
-            update_mask_should_fix = False
-        return update_mask_should_fix
-
-    def update_exclusive_mask(self, link):
-        stack = []
-        current = link
-        while current.parent and not current.all_ancestors_inclusive:
-            parent = current.parent
-            if parent.exclusive:
-                parent.exclusive_mask |= link.code
-                parent.exclusive_links.append(link.name)
-            stack.append(current)
-            current = parent
-
-        while len(stack) > 0:
-            parent = current
-            current = stack.pop()
-            if parent.exclusive:
-                current.exclusive_mask = parent.exclusive_mask ^ current.code
-            else:
-                current.exclusive_mask = parent.exclusive_mask
-            current.exclusive_links = parent.exclusive_links
-
-    def update_parent(self, child):
-        update_mask_should_fix = child.required
-        self.code = child.code if self.code is None else self.code | child.code
-        if update_mask_should_fix:
-            self.existing_mask = child.code if self.existing_mask is None else self.existing_mask | child.code
-            self.existing_links.append(child.name)
-
-        current_sg = self
-        if not current_sg.required:
-            update_mask_should_fix = False
-        if current_sg.required:
-            current_sg.required_links.append(child.name)
-
-        while current_sg is not None:
-            parent = current_sg.parent
-            if parent is not None:
-                if update_mask_should_fix:
-                    update_mask_should_fix = self.update_existing_mask(current_sg, parent, child, update_mask_should_fix)
-                parent.code = current_sg.code if parent.code is None else parent.code | current_sg.code
-                if parent.required:
-                    parent.required_links.append(child.name)
-            current_sg = parent
-        self.update_exclusive_mask(child)
-
-    def add_child_link(self, child):
-        self.update_parent(child)
-
-
-class LinkWithExclusiveMask(object):
-    def __init__(self, item):
-        self.name = item.name
-        self.exclusive_mask = item.exclusive_mask
-        self.exclusive_links = item.exclusive_links
-        self.multiplicity = item.schema.get('multiplicity')
-        self.back_ref = item.schema.get('backref')
-
-
-class ExistingMasks(object):
-    def __init__(self, code, existing_mask, existing_links):
-        self.code = code
-        self.existing_mask = existing_mask
-        self.existing_links = existing_links
-
-
-class RequiredMask(object):
-    def __init__(self):
-        self.list_required_links = []
-        self.group_required = []
-        self.required_mask = 0
-
-
 class GDCNamedLinksValidator(object):
     '''
     First of all, the existence of links in each node is encoded as a bit array. Link has value encoded as 1 and 0 if
@@ -151,108 +52,24 @@ class GDCNamedLinksValidator(object):
 
     '''
     def __init__(self, node_label):
-        self.required_validator, self.existing_list, self.exclusive_list = self.create_subgroup_validators(node_label)
-
-    @staticmethod
-    def create_subgroup_validators(node_label):
-        link_items = []
-        leaves = []
-        for link in gdcdictionary.schema[node_label]['links']:
-            if 'name' in link:
-                l_item = SubgroupParsingNode(None, link, 1 << len(leaves))
-                leaves.append(l_item)
-            else:
-                l_item = SubgroupParsingNode(None, link)
-            link_items.append(l_item)
-
-        return GDCNamedLinksValidator.build_tree_of_link_items(link_items, leaves)
-
-    @staticmethod
-    def build_tree_of_link_items(link_items, leaves):
-        final_required = []
-        current_pos = 0
-        while current_pos < len(link_items):
-            l_item = link_items[current_pos]
-            children_required_count = 0
-            if 'subgroup' in l_item.schema:
-                for link in l_item.schema['subgroup']:
-                    if 'subgroup' in link:
-                        new_l_item = SubgroupParsingNode(l_item, link)
-                    else:
-                        new_l_item = SubgroupParsingNode(l_item, link, 1 << len(leaves))
-                        l_item.add_child_link(new_l_item)
-                        leaves.append(new_l_item)
-
-                    link_items.append(new_l_item)
-
-                    if l_item.required and new_l_item.required:
-                        children_required_count += 1
-            if l_item.all_ancestors_required and l_item.required and children_required_count == 0:
-                final_required.append(l_item)
-            current_pos += 1
-
-        required_validator, base_mask = GDCNamedLinksValidator.create_required_mask(final_required)
-        existing_list = GDCNamedLinksValidator.create_existing_list(link_items, base_mask)
-        exclusive_list = GDCNamedLinksValidator.create_exclusive_list(leaves)
-
-        return required_validator, existing_list, exclusive_list
-
-    @staticmethod
-    def create_exclusive_list(leaves):
-        if len(leaves) == 0:
-            return []
-
-        current = leaves[len(leaves) - 1]
-        leaves_checks = deque([LinkWithExclusiveMask(current)])
-        i = len(leaves) - 2
-        while i >= 0:
-            leaf = leaves[i]
-            if leaf.parent == current.parent:
-                leaf.exclusive_links = current.exclusive_links
-            else:
-                current = leaf
-            leaves_checks.appendleft(LinkWithExclusiveMask(leaf))
-            i -= 1
-        return list(leaves_checks)
-
-    @staticmethod
-    def create_existing_list(link_items, base_mask):
-        existing_masks = []
-        for item in link_items:
-            if item.existing_mask is not None:
-                existing_masks.append(ExistingMasks(item.code, item.existing_mask | base_mask,
-                                                    item.existing_links))
-        return existing_masks
-
-    @staticmethod
-    def create_required_mask(final_required):
-        res = RequiredMask()
-        base_mask = 0
-        for item in final_required:
-            res.required_mask |= item.code
-            if item.name is not None:
-                res.list_required_links.append(item.name)
-                base_mask |= item.code  # if the require is True from the root to the leaf, this leaf is really required
-            else:
-                res.group_required.extend(item.required_links)
-        return res, base_mask
+        self.required_validator, self.existing_list, self.exclusive_list = create_subgroup_validators(node_label)
 
     def validate(self, entity):
-        coded_format = 0
+        submit_value = 0
         current_pos = 0
         # iterate all the links, turn on corresponding bit and doing exclusive check
         for leaf in self.exclusive_list:
             targets = entity.node[leaf.name]
             self.validate_multiplicity(entity, leaf, targets)
             if len(targets) > 0:
-                if coded_format & leaf.exclusive_mask != 0:
+                if submit_value & leaf.exclusive_mask != 0:
                     entity.record_error("Links to {} are exclusive.  More than one was provided."
                                         .format(leaf.exclusive_links), keys=leaf.exclusive_links)
-                coded_format |= 1 << current_pos
+                submit_value |= 1 << current_pos
             current_pos += 1
 
         # doing required check with at-least mask
-        if coded_format & self.required_validator.required_mask == 0:
+        if submit_value & self.required_validator.required_mask == 0:
             entity.record_error("Entity is missing one of required link(s) to {} or groups of {}"
                                 .format(self.required_validator.list_required_links,
                                         self.required_validator.group_required),
@@ -260,7 +77,7 @@ class GDCNamedLinksValidator(object):
 
         # doing existing checks with exact masks
         for existing in self.existing_list:
-            if coded_format & existing.code != 0 and coded_format & existing.existing_mask != existing.existing_mask:
+            if submit_value & existing.code != 0 and submit_value & existing.existing_mask != existing.existing_mask:
                 entity.record_error("Missing one of required link(s) of groups of {}"
                                     .format(existing.existing_links),
                                     keys=existing.existing_links)

--- a/gdcdatamodel/validators/link_validator_parser.py
+++ b/gdcdatamodel/validators/link_validator_parser.py
@@ -149,7 +149,7 @@ def create_exclusive_list(leaves):
     if len(leaves) == 0:
         return []
 
-    current = leaves[len(leaves) - 1]
+    current = leaves[-1]
     leaves_checks = deque([LinkWithExclusiveMask(current)])
     i = len(leaves) - 2
     while i >= 0:
@@ -164,12 +164,11 @@ def create_exclusive_list(leaves):
 
 
 def create_existing_list(link_items, base_mask):
-    existing_masks = []
-    for item in link_items:
-        if item.existing_mask is not None:
-            existing_masks.append(ExistingMasks(item.code, item.existing_mask | base_mask,
-                                                item.existing_links))
-    return existing_masks
+    return [
+        ExistingMasks(item.code, item.existing_mask | base_mask, item.existing_links)
+        for item in link_items
+        if item.existing_mask is not None
+    ]
 
 
 def create_required_mask(final_required):

--- a/gdcdatamodel/validators/link_validator_parser.py
+++ b/gdcdatamodel/validators/link_validator_parser.py
@@ -1,0 +1,185 @@
+from dictionaryutils import dictionary as gdcdictionary
+from collections import deque
+
+
+class SubgroupParsingNode(object):
+    def __init__(self, parent, schema, code=None):
+        self.parent = parent
+        self.schema = schema
+        self.code = code
+        self.name = schema.get('name') if 'name' in schema else None
+        self.required = schema.get('required', False)
+        self.exclusive = schema.get('exclusive', False)
+        self.required_links = []
+        self.existing_mask = None
+        self.existing_links = []
+        self.exclusive_mask = 0
+        self.exclusive_links = []
+        self.all_ancestors_required = parent.all_ancestors_required and parent.required \
+            if parent is not None else self.required
+        self.all_ancestors_inclusive = parent.all_ancestors_inclusive and not parent.exclusive \
+            if parent is not None else not self.exclusive
+
+    def update_existing_mask(self, current, parent, child, update_mask_should_fix):
+        parent.existing_mask = current.existing_mask if parent.existing_mask is None \
+            else parent.existing_mask | current.existing_mask
+        parent.existing_links.append(child.name)
+        current.existing_mask = None
+        current.existing_links = []
+        if not parent.required:
+            update_mask_should_fix = False
+        return update_mask_should_fix
+
+    def update_exclusive_mask(self, link):
+        stack = []
+        current = link
+        while current.parent and not current.all_ancestors_inclusive:
+            parent = current.parent
+            if parent.exclusive:
+                parent.exclusive_mask |= link.code
+                parent.exclusive_links.append(link.name)
+            stack.append(current)
+            current = parent
+
+        while len(stack) > 0:
+            parent = current
+            current = stack.pop()
+            if parent.exclusive:
+                current.exclusive_mask = parent.exclusive_mask ^ current.code
+            else:
+                current.exclusive_mask = parent.exclusive_mask
+            current.exclusive_links = parent.exclusive_links
+
+    def update_parent(self, child):
+        update_mask_should_fix = child.required
+        self.code = child.code if self.code is None else self.code | child.code
+        if update_mask_should_fix:
+            self.existing_mask = child.code if self.existing_mask is None else self.existing_mask | child.code
+            self.existing_links.append(child.name)
+
+        current_sg = self
+        if not current_sg.required:
+            update_mask_should_fix = False
+        if current_sg.required:
+            current_sg.required_links.append(child.name)
+
+        while current_sg is not None:
+            parent = current_sg.parent
+            if parent is not None:
+                if update_mask_should_fix:
+                    update_mask_should_fix = self.update_existing_mask(current_sg, parent, child, update_mask_should_fix)
+                parent.code = current_sg.code if parent.code is None else parent.code | current_sg.code
+                if parent.required:
+                    parent.required_links.append(child.name)
+            current_sg = parent
+        self.update_exclusive_mask(child)
+
+    def add_child_link(self, child):
+        self.update_parent(child)
+
+
+class LinkWithExclusiveMask(object):
+    def __init__(self, item):
+        self.name = item.name
+        self.exclusive_mask = item.exclusive_mask
+        self.exclusive_links = item.exclusive_links
+        self.multiplicity = item.schema.get('multiplicity')
+        self.back_ref = item.schema.get('backref')
+
+
+class ExistingMasks(object):
+    def __init__(self, code, existing_mask, existing_links):
+        self.code = code
+        self.existing_mask = existing_mask
+        self.existing_links = existing_links
+
+
+class RequiredMask(object):
+    def __init__(self):
+        self.list_required_links = []
+        self.group_required = []
+        self.required_mask = 0
+
+
+def create_subgroup_validators(node_label):
+    link_items = []
+    leaves = []
+    for link in gdcdictionary.schema[node_label]['links']:
+        if 'name' in link:
+            l_item = SubgroupParsingNode(None, link, 1 << len(leaves))
+            leaves.append(l_item)
+        else:
+            l_item = SubgroupParsingNode(None, link)
+        link_items.append(l_item)
+
+    return build_tree_of_link_items(link_items, leaves)
+
+
+def build_tree_of_link_items(link_items, leaves):
+    final_required = []
+    current_pos = 0
+    while current_pos < len(link_items):
+        l_item = link_items[current_pos]
+        children_required_count = 0
+        if 'subgroup' in l_item.schema:
+            for link in l_item.schema['subgroup']:
+                if 'subgroup' in link:
+                    new_l_item = SubgroupParsingNode(l_item, link)
+                else:
+                    new_l_item = SubgroupParsingNode(l_item, link, 1 << len(leaves))
+                    l_item.add_child_link(new_l_item)
+                    leaves.append(new_l_item)
+
+                link_items.append(new_l_item)
+
+                if l_item.required and new_l_item.required:
+                    children_required_count += 1
+        if l_item.all_ancestors_required and l_item.required and children_required_count == 0:
+            final_required.append(l_item)
+        current_pos += 1
+
+    required_validator, base_mask = create_required_mask(final_required)
+    existing_list = create_existing_list(link_items, base_mask)
+    exclusive_list = create_exclusive_list(leaves)
+
+    return required_validator, existing_list, exclusive_list
+
+
+def create_exclusive_list(leaves):
+    if len(leaves) == 0:
+        return []
+
+    current = leaves[len(leaves) - 1]
+    leaves_checks = deque([LinkWithExclusiveMask(current)])
+    i = len(leaves) - 2
+    while i >= 0:
+        leaf = leaves[i]
+        if leaf.parent == current.parent:
+            leaf.exclusive_links = current.exclusive_links
+        else:
+            current = leaf
+        leaves_checks.appendleft(LinkWithExclusiveMask(leaf))
+        i -= 1
+    return list(leaves_checks)
+
+
+def create_existing_list(link_items, base_mask):
+    existing_masks = []
+    for item in link_items:
+        if item.existing_mask is not None:
+            existing_masks.append(ExistingMasks(item.code, item.existing_mask | base_mask,
+                                                item.existing_links))
+    return existing_masks
+
+
+def create_required_mask(final_required):
+    res = RequiredMask()
+    base_mask = 0
+    for item in final_required:
+        res.required_mask |= item.code
+        if item.name is not None:
+            res.list_required_links.append(item.name)
+            base_mask |= item.code  # if the require is True from the root to the leaf, this leaf is really required
+        else:
+            res.group_required.extend(item.required_links)
+    return res, base_mask

--- a/gdcdatamodel/validators/link_validator_parser.py
+++ b/gdcdatamodel/validators/link_validator_parser.py
@@ -84,7 +84,7 @@ class LinkWithExclusiveMask(object):
         self.exclusive_mask = item.exclusive_mask
         self.exclusive_links = item.exclusive_links
         self.multiplicity = item.schema.get('multiplicity')
-        self.back_ref = item.schema.get('backref')
+        self.backref = item.schema.get('backref')
 
 
 class ExistingMasks(object):

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -102,6 +102,9 @@ class TestValidators(unittest.TestCase):
     def update_schema(self, entity, key, schema):
         self.graph_validator.schemas.schema[entity][key] = schema
 
+    def append_schema(self, entity, key, schema):
+        self.graph_validator.schemas.schema[entity][key].update(schema)
+
     def test_graph_validator_without_required_link(self):
         with g.session_scope() as session:
             node = self.create_node({'type': 'aliquot',
@@ -198,6 +201,278 @@ class TestValidators(unittest.TestCase):
                        'target_type': 'sample'}]}])
             self.graph_validator.record_errors(g, self.entities)
             self.assertEquals(['analytes'], self.entities[0].errors[0]['keys'])
+
+    # def test_graph_validator_with_invalid_existing_nested_subgroup(self):
+    #     with g.session_scope() as session:
+    #         case = self.create_node({'type': 'case',
+    #                                  'props': {'submitter_id': 'testc'},
+    #                                  'edges': {}}, session)
+    #         sample = self.create_node({'type': 'sample',
+    #                                    'props': {'submitter_id': 'test',
+    #                                              'sample_type': 'DNA',
+    #                                              'sample_type_id': '01'},
+    #                                    'edges': {}}, session)
+    #         node = self.create_node({'type': 'aliquot',
+    #                                  'props': {'submitter_id': 'test'},
+    #                                  'edges': {'cases': [case.node_id],
+    #                                            'samples': [sample.node_id]}},
+    #                                 session)
+    #         self.entities[0].node = node
+    #         self.append_schema('aliquot', 'properties', {
+    #             'cases': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             },
+    #             'treatments': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             },
+    #             'publications': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             }
+    #         })
+    #         self.update_schema(
+    #             'aliquot',
+    #             'links',
+    #             [{'exclusive': False,
+    #               'required': True,
+    #               'subgroup': [
+    #                 {'name': 'case',
+    #                  'backref': 'aliquots',
+    #                  'label': 'derived_from',
+    #                  'multiplicity': 'many_to_one',
+    #                  'target_type': 'case'},
+    #                 {
+    #                   'exclusive': True,
+    #                   'required': False,
+    #                   'subgroup': [
+    #                     {
+    #                       'exclusive': False,
+    #                       'required': False,
+    #                       'subgroup': [
+    #                         {'name': 'treatments',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'treatment',
+    #                          'required': True},
+    #                         {'name': 'samples',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'sample',
+    #                          'required': True}
+    #                       ]
+    #                     },
+    #                     {
+    #                       'exclusive': False,
+    #                       'required': False,
+    #                       'subgroup': [
+    #                         {'name': 'analytes',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'analyte',
+    #                          'required': True},
+    #                         {'name': 'publications',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'publication',
+    #                          'required': True}
+    #                       ]
+    #                     }
+    #                   ]
+    #                 }
+    #             ]}])
+    #         self.graph_validator.record_errors(g, self.entities)
+    #         self.assertEquals(['analytes'], self.entities[0].errors[0]['keys'])
+    #
+    # def test_graph_validator_with_invalid_exclusive_nested_subgroup(self):
+    #     with g.session_scope() as session:
+    #         case = self.create_node({'type': 'case',
+    #                                  'props': {'submitter_id': 'testc'},
+    #                                  'edges': {}}, session)
+    #         analyte = self.create_node({'type': 'analyte',
+    #                                     'props': {'submitter_id': 'test',
+    #                                               'analyte_type_id': 'D',
+    #                                               'analyte_type': 'DNA'},
+    #                                     'edges': {}}, session)
+    #         sample = self.create_node({'type': 'sample',
+    #                                    'props': {'submitter_id': 'test',
+    #                                              'sample_type': 'DNA',
+    #                                              'sample_type_id': '01'},
+    #                                    'edges': {}}, session)
+    #         treatment = self.create_node({'type': 'treatment',
+    #                                       'props': {'submitter_id': 'test',
+    #                                                 'days_to_follow_up': 10},
+    #                                       'edges': {}}, session)
+    #         publication = self.create_node({'type': 'publication',
+    #                                         'props': {'submitter_id': 'test'},
+    #                                         'edges': {}}, session)
+    #
+    #         node = self.create_node({'type': 'aliquot',
+    #                                  'props': {'submitter_id': 'test'},
+    #                                  'edges': {'analytes': [analyte.node_id],
+    #                                            'samples': [sample.node_id],
+    #                                            'treatments': [treatment.node_id],
+    #                                            'publications': [publication.node_id]}},
+    #                                 session)
+    #         self.entities[0].node = node
+    #         self.append_schema('aliquot', 'properties', {
+    #             'cases': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             },
+    #             'treatments': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             },
+    #             'publications': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             }
+    #         })
+    #         self.update_schema(
+    #             'aliquot',
+    #             'links',
+    #             [{'exclusive': False,
+    #               'required': True,
+    #               'subgroup': [
+    #                 {'name': 'case',
+    #                  'backref': 'aliquots',
+    #                  'label': 'derived_from',
+    #                  'multiplicity': 'many_to_one',
+    #                  'target_type': 'case'},
+    #                 {
+    #                   'exclusive': True,
+    #                   'required': False,
+    #                   'subgroup': [
+    #                     {
+    #                       'exclusive': False,
+    #                       'required': False,
+    #                       'subgroup': [
+    #                         {'name': 'treatments',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'treatment',
+    #                          'required': True},
+    #                         {'name': 'samples',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'sample',
+    #                          'required': True}
+    #                       ]
+    #                     },
+    #                     {
+    #                       'exclusive': False,
+    #                       'required': False,
+    #                       'subgroup': [
+    #                         {'name': 'analytes',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'analyte',
+    #                          'required': True},
+    #                         {'name': 'publications',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'publication',
+    #                          'required': True}
+    #                       ]
+    #                     }
+    #                   ]
+    #                 }
+    #             ]}])
+    #         self.graph_validator.record_errors(g, self.entities)
+    #         self.assertEquals(['analytes'], self.entities[0].errors[0]['keys'])
+    #
+    # def test_graph_validator_with_valid_nested_subgroup(self):
+    #     with g.session_scope() as session:
+    #         self.append_schema('aliquot', 'properties', {
+    #             'cases': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             },
+    #             'treatments': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             },
+    #             'publications': {
+    #                 '$ref': '_definitions.yaml#/to_one'
+    #             }
+    #         })
+    #         # case = self.create_node({'type': 'case',
+    #         #                          'props': {'submitter_id': 'testc'},
+    #         #                          'edges': {}}, session)
+    #         sample = self.create_node({'type': 'sample',
+    #                                    'props': {'submitter_id': 'test',
+    #                                              'sample_type': 'DNA',
+    #                                              'sample_type_id': '01'},
+    #                                    'edges': {}}, session)
+    #         # treatment = self.create_node({'type': 'treatment',
+    #         #                               'props': {'submitter_id': 'test',
+    #         #                                         'days_to_follow_up': 10},
+    #         #                               'edges': {}}, session)
+    #         node = self.create_node({'type': 'aliquot',
+    #                                  'props': {'submitter_id': 'test'},
+    #                                  'edges': {#'cases': [case.node_id],
+    #                                            #'treatments': [treatment.node_id],
+    #                                            'samples': [sample.node_id]}},
+    #                                 session)
+    #         self.entities[0].node = node
+    #         self.update_schema(
+    #             'aliquot',
+    #             'links',
+    #             [{'exclusive': False,
+    #               'required': True,
+    #               'subgroup': [
+    #                 {'name': 'case',
+    #                  'backref': 'aliquots',
+    #                  'label': 'derived_from',
+    #                  'multiplicity': 'many_to_one',
+    #                  'target_type': 'case'},
+    #                 {
+    #                   'exclusive': True,
+    #                   'required': True,
+    #                   'subgroup': [
+    #                     {
+    #                       'exclusive': False,
+    #                       'required': True,
+    #                       'subgroup': [
+    #                         {'name': 'treatments',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'treatment',
+    #                          'required': True},
+    #                         {'name': 'samples',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'sample',
+    #                          'required': True}
+    #                       ]
+    #                     },
+    #                     {
+    #                       'exclusive': False,
+    #                       'required': False,
+    #                       'subgroup': [
+    #                         {'name': 'analytes',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'analyte',
+    #                          'required': True},
+    #                         {'name': 'publications',
+    #                          'backref': 'aliquots',
+    #                          'label': 'derived_from',
+    #                          'multiplicity': 'many_to_one',
+    #                          'target_type': 'publication',
+    #                          'required': True}
+    #                       ]
+    #                     }
+    #                   ]
+    #                 }
+    #             ]}])
+    #         self.graph_validator.record_errors(g, self.entities)
+    #         self.assertEquals(0, len(self.entities[0].errors))
 
     def test_graph_validator_with_correct_node(self):
         with g.session_scope() as session:

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -202,277 +202,228 @@ class TestValidators(unittest.TestCase):
             self.graph_validator.record_errors(g, self.entities)
             self.assertEquals(['analytes'], self.entities[0].errors[0]['keys'])
 
-    # def test_graph_validator_with_invalid_existing_nested_subgroup(self):
-    #     with g.session_scope() as session:
-    #         case = self.create_node({'type': 'case',
-    #                                  'props': {'submitter_id': 'testc'},
-    #                                  'edges': {}}, session)
-    #         sample = self.create_node({'type': 'sample',
-    #                                    'props': {'submitter_id': 'test',
-    #                                              'sample_type': 'DNA',
-    #                                              'sample_type_id': '01'},
-    #                                    'edges': {}}, session)
-    #         node = self.create_node({'type': 'aliquot',
-    #                                  'props': {'submitter_id': 'test'},
-    #                                  'edges': {'cases': [case.node_id],
-    #                                            'samples': [sample.node_id]}},
-    #                                 session)
-    #         self.entities[0].node = node
-    #         self.append_schema('aliquot', 'properties', {
-    #             'cases': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             },
-    #             'treatments': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             },
-    #             'publications': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             }
-    #         })
-    #         self.update_schema(
-    #             'aliquot',
-    #             'links',
-    #             [{'exclusive': False,
-    #               'required': True,
-    #               'subgroup': [
-    #                 {'name': 'case',
-    #                  'backref': 'aliquots',
-    #                  'label': 'derived_from',
-    #                  'multiplicity': 'many_to_one',
-    #                  'target_type': 'case'},
-    #                 {
-    #                   'exclusive': True,
-    #                   'required': False,
-    #                   'subgroup': [
-    #                     {
-    #                       'exclusive': False,
-    #                       'required': False,
-    #                       'subgroup': [
-    #                         {'name': 'treatments',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'treatment',
-    #                          'required': True},
-    #                         {'name': 'samples',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'sample',
-    #                          'required': True}
-    #                       ]
-    #                     },
-    #                     {
-    #                       'exclusive': False,
-    #                       'required': False,
-    #                       'subgroup': [
-    #                         {'name': 'analytes',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'analyte',
-    #                          'required': True},
-    #                         {'name': 'publications',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'publication',
-    #                          'required': True}
-    #                       ]
-    #                     }
-    #                   ]
-    #                 }
-    #             ]}])
-    #         self.graph_validator.record_errors(g, self.entities)
-    #         self.assertEquals(['analytes'], self.entities[0].errors[0]['keys'])
-    #
-    # def test_graph_validator_with_invalid_exclusive_nested_subgroup(self):
-    #     with g.session_scope() as session:
-    #         case = self.create_node({'type': 'case',
-    #                                  'props': {'submitter_id': 'testc'},
-    #                                  'edges': {}}, session)
-    #         analyte = self.create_node({'type': 'analyte',
-    #                                     'props': {'submitter_id': 'test',
-    #                                               'analyte_type_id': 'D',
-    #                                               'analyte_type': 'DNA'},
-    #                                     'edges': {}}, session)
-    #         sample = self.create_node({'type': 'sample',
-    #                                    'props': {'submitter_id': 'test',
-    #                                              'sample_type': 'DNA',
-    #                                              'sample_type_id': '01'},
-    #                                    'edges': {}}, session)
-    #         treatment = self.create_node({'type': 'treatment',
-    #                                       'props': {'submitter_id': 'test',
-    #                                                 'days_to_follow_up': 10},
-    #                                       'edges': {}}, session)
-    #         publication = self.create_node({'type': 'publication',
-    #                                         'props': {'submitter_id': 'test'},
-    #                                         'edges': {}}, session)
-    #
-    #         node = self.create_node({'type': 'aliquot',
-    #                                  'props': {'submitter_id': 'test'},
-    #                                  'edges': {'analytes': [analyte.node_id],
-    #                                            'samples': [sample.node_id],
-    #                                            'treatments': [treatment.node_id],
-    #                                            'publications': [publication.node_id]}},
-    #                                 session)
-    #         self.entities[0].node = node
-    #         self.append_schema('aliquot', 'properties', {
-    #             'cases': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             },
-    #             'treatments': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             },
-    #             'publications': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             }
-    #         })
-    #         self.update_schema(
-    #             'aliquot',
-    #             'links',
-    #             [{'exclusive': False,
-    #               'required': True,
-    #               'subgroup': [
-    #                 {'name': 'case',
-    #                  'backref': 'aliquots',
-    #                  'label': 'derived_from',
-    #                  'multiplicity': 'many_to_one',
-    #                  'target_type': 'case'},
-    #                 {
-    #                   'exclusive': True,
-    #                   'required': False,
-    #                   'subgroup': [
-    #                     {
-    #                       'exclusive': False,
-    #                       'required': False,
-    #                       'subgroup': [
-    #                         {'name': 'treatments',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'treatment',
-    #                          'required': True},
-    #                         {'name': 'samples',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'sample',
-    #                          'required': True}
-    #                       ]
-    #                     },
-    #                     {
-    #                       'exclusive': False,
-    #                       'required': False,
-    #                       'subgroup': [
-    #                         {'name': 'analytes',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'analyte',
-    #                          'required': True},
-    #                         {'name': 'publications',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'publication',
-    #                          'required': True}
-    #                       ]
-    #                     }
-    #                   ]
-    #                 }
-    #             ]}])
-    #         self.graph_validator.record_errors(g, self.entities)
-    #         self.assertEquals(['analytes'], self.entities[0].errors[0]['keys'])
-    #
-    # def test_graph_validator_with_valid_nested_subgroup(self):
-    #     with g.session_scope() as session:
-    #         self.append_schema('aliquot', 'properties', {
-    #             'cases': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             },
-    #             'treatments': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             },
-    #             'publications': {
-    #                 '$ref': '_definitions.yaml#/to_one'
-    #             }
-    #         })
-    #         # case = self.create_node({'type': 'case',
-    #         #                          'props': {'submitter_id': 'testc'},
-    #         #                          'edges': {}}, session)
-    #         sample = self.create_node({'type': 'sample',
-    #                                    'props': {'submitter_id': 'test',
-    #                                              'sample_type': 'DNA',
-    #                                              'sample_type_id': '01'},
-    #                                    'edges': {}}, session)
-    #         # treatment = self.create_node({'type': 'treatment',
-    #         #                               'props': {'submitter_id': 'test',
-    #         #                                         'days_to_follow_up': 10},
-    #         #                               'edges': {}}, session)
-    #         node = self.create_node({'type': 'aliquot',
-    #                                  'props': {'submitter_id': 'test'},
-    #                                  'edges': {#'cases': [case.node_id],
-    #                                            #'treatments': [treatment.node_id],
-    #                                            'samples': [sample.node_id]}},
-    #                                 session)
-    #         self.entities[0].node = node
-    #         self.update_schema(
-    #             'aliquot',
-    #             'links',
-    #             [{'exclusive': False,
-    #               'required': True,
-    #               'subgroup': [
-    #                 {'name': 'case',
-    #                  'backref': 'aliquots',
-    #                  'label': 'derived_from',
-    #                  'multiplicity': 'many_to_one',
-    #                  'target_type': 'case'},
-    #                 {
-    #                   'exclusive': True,
-    #                   'required': True,
-    #                   'subgroup': [
-    #                     {
-    #                       'exclusive': False,
-    #                       'required': True,
-    #                       'subgroup': [
-    #                         {'name': 'treatments',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'treatment',
-    #                          'required': True},
-    #                         {'name': 'samples',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'sample',
-    #                          'required': True}
-    #                       ]
-    #                     },
-    #                     {
-    #                       'exclusive': False,
-    #                       'required': False,
-    #                       'subgroup': [
-    #                         {'name': 'analytes',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'analyte',
-    #                          'required': True},
-    #                         {'name': 'publications',
-    #                          'backref': 'aliquots',
-    #                          'label': 'derived_from',
-    #                          'multiplicity': 'many_to_one',
-    #                          'target_type': 'publication',
-    #                          'required': True}
-    #                       ]
-    #                     }
-    #                   ]
-    #                 }
-    #             ]}])
-    #         self.graph_validator.record_errors(g, self.entities)
-    #         self.assertEquals(0, len(self.entities[0].errors))
+    def test_graph_validator_with_invalid_existing_nested_subgroup(self):
+        with g.session_scope() as session:
+            submitted_unaligned_reads = self.create_node({'type': 'submitted_unaligned_reads',
+                                                          'props': {'submitter_id': 'test',
+                                                                    'file_name': 'test_file1',
+                                                                    'data_format': 'BAM',
+                                                                    'data_category': 'Sequencing Data',
+                                                                    'data_type': 'Unaligned Reads'},
+                                                          'edges': {}}, session)
+            alignment_workflow = self.create_node({'type': 'alignment_workflow',
+                                                   'props': {'submitter_id': 'test',
+                                                             'workflow_link': 'alignment_workflow',
+                                                             'workflow_type': 'STAR 2-Pass'},
+                                                   'edges': {}}, session)
+
+            node = self.create_node({'type': 'aligned_reads',
+                                     'props': {'submitter_id': 'test'},
+                                     'edges': {'submitted_unaligned_reads_files': [submitted_unaligned_reads.node_id],
+                                               'alignment_workflows': [alignment_workflow.node_id]}},
+                                    session)
+            self.entities[0].node = node
+            self.update_schema(
+                'aligned_reads',
+                'links',
+                [{'exclusive': False,
+                  'required': True,
+                  'subgroup': [
+                    {'name': 'submitted_unaligned_reads_files',
+                     'backref': 'aligned_reads_files',
+                     'label': 'matched_to',
+                     'multiplicity': 'one_to_many',
+                     'target_type': 'submitted_unaligned_reads'},
+                    {
+                      'exclusive': True,
+                      'required': False,
+                      'subgroup': [
+                        {'name': 'submitted_aligned_reads_files',
+                         'backref': 'aligned_reads',
+                         'label': 'matched_to',
+                         'multiplicity': 'one_to_one',
+                         'target_type': 'submitted_aligned_reads',
+                         'required': False},
+                        {
+                          'exclusive': False,
+                          'required': False,
+                          'subgroup': [
+                            {'name': 'alignment_cocleaning_workflows',
+                             'backref': 'aligned_reads_files',
+                             'label': 'data_from',
+                             'multiplicity': 'many_to_one',
+                             'target_type': 'alignment_cocleaning_workflow',
+                             'required': True},
+                            {'name': 'alignment_workflows',
+                             'backref': 'aligned_reads_files',
+                             'label': 'data_from',
+                             'multiplicity': 'many_to_one',
+                             'target_type': 'alignment_workflow',
+                             'required': True}
+                          ]
+                        }
+                      ]
+                    }
+                  ]}
+                 ])
+            self.graph_validator.record_errors(g, self.entities)
+            self.assertEquals(['alignment_cocleaning_workflows', 'alignment_workflows'], self.entities[0].errors[0]['keys'])
+
+    def test_graph_validator_with_invalid_exclusive_nested_subgroup(self):
+        with g.session_scope() as session:
+            # submitted_aligned_reads = self.create_node({'type': 'submitted_aligned_reads',
+            #                                               'props': {'submitter_id': 'test',
+            #                                                         'file_name': 'test_file1',
+            #                                                         'data_format': 'BAM',
+            #                                                         'data_category': 'Sequencing Data',
+            #                                                         'data_type': 'Aligned Reads'},
+            #                                               'edges': {}}, session)
+            submitted_unaligned_reads = self.create_node({'type': 'submitted_unaligned_reads',
+                                                          'props': {'submitter_id': 'test',
+                                                                    'file_name': 'test_file1',
+                                                                    'data_format': 'BAM',
+                                                                    'data_category': 'Sequencing Data',
+                                                                    'data_type': 'Unaligned Reads'},
+                                                          'edges': {}}, session)
+            alignment_cocleaning_workflow = self.create_node({'type': 'alignment_cocleaning_workflow',
+                                                              'props': {'submitter_id': 'test',
+                                                                        'workflow_link': 'work link 1',
+                                                                        'workflow_type': 'BWA with Mark Duplicates and Cocleaning'},
+                                                              'edges': {}}, session)
+            alignment_workflow = self.create_node({'type': 'alignment_workflow',
+                                                   'props': {'submitter_id': 'test',
+                                                             'workflow_link': 'alignment_workflow',
+                                                             'workflow_type': 'STAR 2-Pass'},
+                                                   'edges': {}}, session)
+
+            node = self.create_node({'type': 'aligned_reads',
+                                     'props': {'submitter_id': 'test'},
+                                     'edges': {#'submitted_aligned_reads_files': [submitted_aligned_reads.node_id],
+                                               'submitted_unaligned_reads_files': [submitted_unaligned_reads.node_id],
+                                               'alignment_cocleaning_workflows': [alignment_cocleaning_workflow.node_id],
+                                               'alignment_workflows': [alignment_workflow.node_id]}},
+                                    session)
+            self.entities[0].node = node
+            self.update_schema(
+                'aligned_reads',
+                'links',
+                [{'exclusive': False,
+                  'required': True,
+                  'subgroup': [
+                    {'name': 'submitted_aligned_reads_files',
+                     'backref': 'aligned_reads',
+                     'label': 'matched_to',
+                     'multiplicity': 'one_to_one',
+                     'target_type': 'submitted_aligned_reads'},
+                    {
+                      'exclusive': True,
+                      'required': False,
+                      'subgroup': [
+                        {'name': 'submitted_unaligned_reads_files',
+                         'backref': 'aligned_reads_files',
+                         'label': 'matched_to',
+                         'multiplicity': 'one_to_many',
+                         'target_type': 'submitted_unaligned_reads',
+                         'required': False},
+                        {
+                          'exclusive': False,
+                          'required': False,
+                          'subgroup': [
+                            {'name': 'alignment_cocleaning_workflows',
+                             'backref': 'aligned_reads_files',
+                             'label': 'data_from',
+                             'multiplicity': 'many_to_one',
+                             'target_type': 'alignment_cocleaning_workflow',
+                             'required': True},
+                            {'name': 'alignment_workflows',
+                             'backref': 'aligned_reads_files',
+                             'label': 'data_from',
+                             'multiplicity': 'many_to_one',
+                             'target_type': 'alignment_workflow',
+                             'required': True}
+                          ]
+                        }
+                      ]
+                    }
+                  ]}
+                 ])
+            self.graph_validator.record_errors(g, self.entities)
+            self.assertEquals(['submitted_unaligned_reads_files', 'alignment_cocleaning_workflows', 'alignment_workflows'],
+                              self.entities[0].errors[0]['keys'])
+
+    def test_graph_validator_with_valid_nested_subgroup(self):
+        with g.session_scope() as session:
+            submitted_unaligned_reads = self.create_node({'type': 'submitted_unaligned_reads',
+                                                          'props': {'submitter_id': 'test',
+                                                                    'file_name': 'test_file1',
+                                                                    'data_format': 'BAM',
+                                                                    'data_category': 'Sequencing Data',
+                                                                    'data_type': 'Unaligned Reads'},
+                                                          'edges': {}}, session)
+            alignment_cocleaning_workflow = self.create_node({'type': 'alignment_cocleaning_workflow',
+                                                              'props': {'submitter_id': 'test',
+                                                                        'workflow_link': 'work link 1',
+                                                                        'workflow_type': 'BWA with Mark Duplicates and Cocleaning'},
+                                                              'edges': {}}, session)
+            alignment_workflow = self.create_node({'type': 'alignment_workflow',
+                                                   'props': {'submitter_id': 'test',
+                                                             'workflow_link': 'alignment_workflow',
+                                                             'workflow_type': 'STAR 2-Pass'},
+                                                   'edges': {}}, session)
+
+            node = self.create_node({'type': 'aligned_reads',
+                                     'props': {'submitter_id': 'test'},
+                                     'edges': {'submitted_unaligned_reads_files': [submitted_unaligned_reads.node_id],
+                                               'alignment_cocleaning_workflows': [
+                                                   alignment_cocleaning_workflow.node_id],
+                                               'alignment_workflows': [alignment_workflow.node_id]}},
+                                    session)
+            self.entities[0].node = node
+            self.update_schema(
+                'aligned_reads',
+                'links',
+                [{'exclusive': False,
+                  'required': True,
+                  'subgroup': [
+                    {'name': 'submitted_unaligned_reads_files',
+                     'backref': 'aligned_reads_files',
+                     'label': 'matched_to',
+                     'multiplicity': 'one_to_many',
+                     'target_type': 'submitted_unaligned_reads'},
+                    {
+                      'exclusive': True,
+                      'required': False,
+                      'subgroup': [
+                        {'name': 'submitted_aligned_reads_files',
+                         'backref': 'aligned_reads',
+                         'label': 'matched_to',
+                         'multiplicity': 'one_to_one',
+                         'target_type': 'submitted_aligned_reads',
+                         'required': False},
+                        {
+                          'exclusive': False,
+                          'required': False,
+                          'subgroup': [
+                            {'name': 'alignment_cocleaning_workflows',
+                             'backref': 'aligned_reads_files',
+                             'label': 'data_from',
+                             'multiplicity': 'many_to_one',
+                             'target_type': 'alignment_cocleaning_workflow',
+                             'required': True},
+                            {'name': 'alignment_workflows',
+                             'backref': 'aligned_reads_files',
+                             'label': 'data_from',
+                             'multiplicity': 'many_to_one',
+                             'target_type': 'alignment_workflow',
+                             'required': True}
+                          ]
+                        }
+                      ]
+                    }
+                  ]}
+                 ])
+            self.graph_validator.record_errors(g, self.entities)
+            self.assertEquals(0, len(self.entities[0].errors))
 
     def test_graph_validator_with_correct_node(self):
         with g.session_scope() as session:


### PR DESCRIPTION
Support nested subgroup declaration and improve the link validators


### New Features
- support nested subgroup logic that appears in this dictionary versioned
https://github.com/uc-cdis/gtex-dictionary/blob/523df8967bf9155a1c11a2d82888e20d3fe9fb9f/gdcdictionary/schemas/aligned_reads.yaml#L28-L67 . In this logic, subgroup has `required = false` while its children links can have `required = true`. Then if there exists value for one of required children, all values must exist for all required children. Let's call it `existing group` logic.
- encoded all `required`, `exclusive` and `existing group` logic to a bit maskings. Cache these bit masking logics for a node to avoid looping and calling recursive function when submitting multiple records of a node. 

### Breaking Changes


### Bug Fixes


### Improvements
- improve link validation's speed
- support new logic

### Dependency updates


### Deployment changes

