### PR TITLE
(PPS-710): update dictionaryutils to new release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -282,8 +282,8 @@ requests = "*"
 [package.source]
 type = "git"
 url = "https://github.com/uc-cdis/dictionaryutils"
-reference = "chore/update-jsonschema"
-resolved_reference = "d1eee48ed69e7ced35a86a182951a4b5f4609f7e"
+reference = "3.4.11"
+resolved_reference = "cbac4bf51febc64eab4875f84ca6cb15c8b4718e"
 
 [[package]]
 name = "exceptiongroup"
@@ -863,4 +863,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7cf39ed9932b236fa300ad3a0254d7a67a20e8b201a5ba5cc253f99d5fbf34fc"
+content-hash = "364df350a99f4b12abda1ee7cfd18941e2f52fca711127fb048966c0ccf0a780"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/uc-cdis/gen3datamodel"
 [tool.poetry.dependencies]
 python = "^3.9"
 cdislogging = "*"
-dictionaryutils = {git = "https://github.com/uc-cdis/dictionaryutils", branch = "chore/update-jsonschema"}
+dictionaryutils = {git = "https://github.com/uc-cdis/dictionaryutils", rev = "3.4.11" }
 # set 'develop = true' to prevent over-writing by 'gen3dictionary', similar to
 # https://github.com/uc-cdis/gen3datamodel/blob/190f99885c660a2971ec64522168548e19bea512/Pipfile#L16
 gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "release/py3", develop = true}


### PR DESCRIPTION
Relates to [PXP-11243](https://ctds-planx.atlassian.net/browse/PXP-11243) and [PPS-710](https://ctds-planx.atlassian.net/browse/PPS-710) 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
* Use new release of dictionaryutils

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PXP-11243]: https://ctds-planx.atlassian.net/browse/PXP-11243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPS-710]: https://ctds-planx.atlassian.net/browse/PPS-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ