### PR TITLE
(PPS-710): replace github reference with PyPI version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -269,21 +269,16 @@ name = "dictionaryutils"
 version = "3.4.11"
 description = "Python wrapper and metaschema for datadictionary."
 optional = false
-python-versions = ">=3.9, <4"
-files = []
-develop = false
+python-versions = "<4,>=3.9"
+files = [
+    {file = "dictionaryutils-3.4.11.tar.gz", hash = "sha256:a63ae34b4c0130cd94e4ca685cbb18155c225f9bface32ed1d503393d0dd39cf"},
+]
 
 [package.dependencies]
 cdislogging = "*"
 jsonschema = "<=4.23.0"
 PyYAML = "*"
 requests = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/uc-cdis/dictionaryutils"
-reference = "3.4.11"
-resolved_reference = "cbac4bf51febc64eab4875f84ca6cb15c8b4718e"
 
 [[package]]
 name = "exceptiongroup"
@@ -863,4 +858,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "364df350a99f4b12abda1ee7cfd18941e2f52fca711127fb048966c0ccf0a780"
+content-hash = "55f732d5cca47480042eb649d7e5a6f5672b221025010734ee9de4a40b269e0b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -310,8 +310,8 @@ PyYAML = "*"
 [package.source]
 type = "git"
 url = "https://github.com/NCI-GDC/gdcdictionary.git"
-reference = "release/py3"
-resolved_reference = "b5db4e815794c0544bbc9f4b6a16fc5b0475363b"
+reference = "2.0.0"
+resolved_reference = "0427dc737a7cc165868f3d065529d20a68a20ac1"
 
 [[package]]
 name = "idna"
@@ -858,4 +858,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "55f732d5cca47480042eb649d7e5a6f5672b221025010734ee9de4a40b269e0b"
+content-hash = "5dae29f04c69d8ddf9a8badf6c36ad0c5e64872c6f59b78bd7849245545ff299"

--- a/poetry.lock
+++ b/poetry.lock
@@ -295,25 +295,6 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "gdcdictionary"
-version = "2.0.0"
-description = ""
-optional = false
-python-versions = "*"
-files = []
-develop = true
-
-[package.dependencies]
-jsonschema = "*"
-PyYAML = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/NCI-GDC/gdcdictionary.git"
-reference = "2.0.0"
-resolved_reference = "0427dc737a7cc165868f3d065529d20a68a20ac1"
-
-[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -858,4 +839,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5dae29f04c69d8ddf9a8badf6c36ad0c5e64872c6f59b78bd7849245545ff299"
+content-hash = "194f491fc9f78d11afcee532832448c39773d768c0a50843b304493a22e71de6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ cdislogging = "*"
 dictionaryutils = ">=3.4.11"
 # set 'develop = true' to prevent over-writing by 'gen3dictionary', similar to
 # https://github.com/uc-cdis/gen3datamodel/blob/190f99885c660a2971ec64522168548e19bea512/Pipfile#L16
-gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "release/py3", develop = true}
+gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "2.0.0", develop = true}
 jsonschema = "*"
 pyrsistent = "==0.15.4"
 pytz = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "gen3datamodel"
 homepage = "https://gen3.org/"
-version = "3.2.0"
+version = "3.2.2"
 description = ""
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ cdislogging = "*"
 dictionaryutils = ">=3.4.11"
 # set 'develop = true' to prevent over-writing by 'gen3dictionary', similar to
 # https://github.com/uc-cdis/gen3datamodel/blob/190f99885c660a2971ec64522168548e19bea512/Pipfile#L16
-gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "2.0.0", develop = true}
+# gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "2.0.0", develop = true}
 jsonschema = "*"
 pyrsistent = "==0.15.4"
 pytz = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/uc-cdis/gen3datamodel"
 [tool.poetry.dependencies]
 python = "^3.9"
 cdislogging = "*"
-dictionaryutils = {git = "https://github.com/uc-cdis/dictionaryutils", rev = "3.4.11" }
+dictionaryutils = ">=3.4.11"
 # set 'develop = true' to prevent over-writing by 'gen3dictionary', similar to
 # https://github.com/uc-cdis/gen3datamodel/blob/190f99885c660a2971ec64522168548e19bea512/Pipfile#L16
 gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "release/py3", develop = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/uc-cdis/gen3datamodel"
 python = "^3.9"
 cdislogging = "*"
 dictionaryutils = ">=3.4.11"
-# set 'develop = true' to prevent over-writing by 'gen3dictionary', similar to
-# https://github.com/uc-cdis/gen3datamodel/blob/190f99885c660a2971ec64522168548e19bea512/Pipfile#L16
-# gdcdictionary = {git = "https://github.com/NCI-GDC/gdcdictionary.git", rev = "2.0.0", develop = true}
 jsonschema = "*"
 pyrsistent = "==0.15.4"
 pytz = "*"


### PR DESCRIPTION
Relates to [PXP-11243](https://ctds-planx.atlassian.net/browse/PXP-11243) and [PPS-710](https://ctds-planx.atlassian.net/browse/PPS-710)

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

* Replace github reference with PyPI version of dictionaryutils

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PXP-11243]: https://ctds-planx.atlassian.net/browse/PXP-11243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPS-710]: https://ctds-planx.atlassian.net/browse/PPS-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ